### PR TITLE
Switch to python3

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -60,7 +60,7 @@ BINFile=../bin/
 default: all
 
 lut.hpp: make_lut.py
-		python make_lut.py > lut.hpp
+		python3 make_lut.py > lut.hpp
 
 io.o: io.hpp io.cpp debug.h dummies.hpp kmer.hpp
 		$(CXX) $(CPP_FLAGS) -c io.cpp $(DEP_FLAGS)

--- a/src/make_lut.py
+++ b/src/make_lut.py
@@ -26,5 +26,6 @@ all_bytes = np.array(range(256), np.uint8)
 rev_bytes = reverse_8(all_bytes)
 rev_comps = complement(rev_bytes)
 
-print src % (",\n ".join(map(hex, rev_bytes.tolist())),
-             ",\n  ".join(map(hex,rev_comps.tolist())))
+print(src % (",\n ".join(map(hex, rev_bytes.tolist())),
+             ",\n  ".join(map(hex,rev_comps.tolist()))))
+


### PR DESCRIPTION
This PR changes `make_lut.py` to be compatible with python3, and uses python3 in the Makefile.